### PR TITLE
make sure detectTerminalColor() doesn't panic on macOS

### DIFF
--- a/detect_unix.go
+++ b/detect_unix.go
@@ -3,6 +3,7 @@
 package box
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -27,15 +28,17 @@ func errorMsg(msg string) {
 func detectTerminalColor() terminfo.ColorLevel {
 	// Detect WSL as it has True Color support
 	wsl, err := ioutil.ReadFile("/proc/sys/kernel/osrelease")
-	if err != nil {
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		log.Fatal(err)
 	}
 	// Lowercasing every content inside "/proc/sys/kernal/osrelease"
 	// because it gives "Microsoft" for WSL and "microsoft" for WSL 2
 	// so no need of checking twice
-	wslLower := strings.ToLower(string(wsl))
-	if strings.Contains(wslLower, "microsoft") {
-		return terminfo.ColorLevelMillions
+	if string(wsl) != "" {
+		wslLower := strings.ToLower(string(wsl))
+		if strings.Contains(wslLower, "microsoft") {
+			return terminfo.ColorLevelMillions
+		}
 	}
 	level, err := terminfo.ColorLevelFromEnv()
 	if err != nil {


### PR DESCRIPTION
Hi @sharifelgamal! Thanks for forking my repo and fixing this issue. I didn't encounter this as I don't have a Mac OS 😅

I hope I can PR these changes to my main repo.