### PR TITLE
Allowing Title Manipulation

### DIFF
--- a/box.go
+++ b/box.go
@@ -129,9 +129,9 @@ func (b Box) toString(title string, lines []string) string {
 	var TitleBar string
 	// If title has tabs then expand them accordingly.
 	if strings.Contains(title, "\t") {
-		TitleBar = repeatWithString(b.Horizontal, n-2, xstrings.ExpandTabs(color.ClearCode(title), 4))
+		TitleBar = repeatWithString(b.Horizontal, n-2, xstrings.ExpandTabs(title, 4))
 	} else {
-		TitleBar = repeatWithString(b.Horizontal, n-2, color.ClearCode(title))
+		TitleBar = repeatWithString(b.Horizontal, n-2, title)
 		//fmt.Println(TitleBar)
 	}
 

--- a/util.go
+++ b/util.go
@@ -81,7 +81,8 @@ func longestLine(lines []string) (int, []expandedLine) {
 }
 
 func repeatWithString(c string, n int, str string) string {
-	count := n - runewidth.StringWidth(str) - 2
+	cstr := color.ClearCode(str)
+	count := n - runewidth.StringWidth(cstr) - 2
 	bar := strings.Repeat(c, count)
 	strNew := fmt.Sprintf(" %s %s", str, bar)
 	return strNew
@@ -103,8 +104,19 @@ func (b Box) checkColorType(topBar, bottomBar, title string) (string, string) {
 				}
 			} else if _, ok := fgColors[str]; ok {
 				Style = fgColors[str].Sprint
-				topBar = Style(topBar)
-				bottomBar = Style(bottomBar)
+				topbars := strings.Split(topBar, "\033[0m")
+				var tmpTopBar string
+				for _, t := range topbars {
+					tmpTopBar += Style(t)
+				}
+				topBar = tmpTopBar
+
+				bottombars := strings.Split(bottomBar, "\033[0m")
+				var tmpBottomBar string
+				for _, t := range bottombars {
+					tmpBottomBar += Style(t)
+				}
+				bottomBar = tmpBottomBar
 			} else {
 				// Return TopBar and BottomBar with a warning as Color provided as a string is unknown
 				errorMsg("[warning]: invalid value provided to Color, using default")

--- a/util.go
+++ b/util.go
@@ -104,19 +104,8 @@ func (b Box) checkColorType(topBar, bottomBar, title string) (string, string) {
 				}
 			} else if _, ok := fgColors[str]; ok {
 				Style = fgColors[str].Sprint
-				topbars := strings.Split(topBar, "\033[0m")
-				var tmpTopBar string
-				for _, t := range topbars {
-					tmpTopBar += Style(t)
-				}
-				topBar = tmpTopBar
-
-				bottombars := strings.Split(bottomBar, "\033[0m")
-				var tmpBottomBar string
-				for _, t := range bottombars {
-					tmpBottomBar += Style(t)
-				}
-				bottomBar = tmpBottomBar
+				topBar = addStylePreservingOriginalFormat(topBar, Style)
+				bottomBar = addStylePreservingOriginalFormat(bottomBar, Style)
 			} else {
 				// Return TopBar and BottomBar with a warning as Color provided as a string is unknown
 				errorMsg("[warning]: invalid value provided to Color, using default")
@@ -166,6 +155,16 @@ func (b Box) checkColorType(topBar, bottomBar, title string) (string, string) {
 	}
 	// As b.Color is nil then apply no color effect and return
 	return topBar, bottomBar
+}
+
+// addStylePreservingOriginalFormat allors to add style around the orginal formating
+func addStylePreservingOriginalFormat(s string, f func(a ...interface{}) string) string {
+	bars := strings.Split(s, "\033[0m") // split by the exit tag code
+	var tmpTopBar string
+	for _, t := range bars {
+		tmpTopBar += f(t) // add the style after each exit code to restart the style around the initial formating
+	}
+	return tmpTopBar
 }
 
 // formatLine formats the line according to the information passed


### PR DESCRIPTION
In order to fix #31 :

* I moved color.ClearCode to inside repeatWithString function (where I created a clean string for counting, and the no-altered string is used for print
* After have done that I need now to add color before the command lines tag and after, so for that on checkColorType I split the string by the exit tag, and I add after it the style back.

There is 2 questions now :
* you know better your code, is it a good (non breaking) commit ?
* That PR allows to change the color of the text by yourself (let's say I want to have a rainbow as title), Is it what you want ? 