### PR TITLE
fix(ci): add lint job and update build steps

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,15 +2,33 @@ name: Go
 on: [push]
 
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v5
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
-          go-version: '1.23.x'
+          go-version: '1.24.x'
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v8
+        with:
+          version: latest
+
+  build-and-test:
+    needs: lint
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v5
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.24.x'
       - name: Install dependencies
         run: go get .
       - name: Build

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           go-version: '1.24.x'
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@v9
         with:
           version: latest
 


### PR DESCRIPTION
## Overview
This PR
- fixes #51 
- fixes #52

issues by adding `windows` image to the pipeline and `lint` job.

## Summary of changes

1. Add `windows-latest` image and made the `build-and-test` job to wait until the `lint` passes, else skipped.
  ```diff
  +  build-and-test:
  +  needs: lint
  +  strategy:
  +     matrix:
  +       os: [ubuntu-latest, windows-latest]
  +  runs-on: ${{ matrix.os }}

  ```
2. Add `lint` job with `golangci-lint-action`
  ```diff
  +  lint:
  +    runs-on: ubuntu-latest
  +    steps:
  +      - uses: actions/checkout@v5
  +      - name: Setup Go
  +        uses: actions/setup-go@v6
  +        with:
  +          go-version: '1.24.x'
  +      - name: Run golangci-lint
  +        uses: golangci/golangci-lint-action@v8
  +        with:
  +          version: latest
  ```

1. Bump `setup-go` action from `v5` to `v6`
  ```diff
  - uses: actions/setup-go@v5
  + uses: actions/setup-go@v6
  ```  
2. Bump `go-version` from `v1.23.x` to `v1.24.x` as the latest module's version support go version `>= v1.24.x`
  ```diff
  - go-version: '1.23.x'
  + go-version: '1.24.x'
  ```