### PR TITLE
feat(box): implement margin support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Box CLI Maker is a Go library for rendering highly customizable boxes in the ter
 - 9 built‑in styles (Single, Double, Round, Bold, SingleDouble, DoubleSingle, Classic, Hidden, Block)
 - Custom glyphs for all corners and edges
 - Title positions: Inside, Top, Bottom
-- Title & Content alignment: Left, Center, Right
+- Title and Content alignment: Left, Center, Right
 - Optional content wrapping with `WrapContent` and `WrapLimit`
 - Color support with:
   - First 16 ANSI color names
@@ -49,6 +49,7 @@ func main() {
     b := box.NewBox().
     Style(box.Single).  // single-line border
     Padding(2, 1).      // inner padding: x (horizontal), y (vertical)
+    Margin(3, 5).       // outer margin: x (horizontal), y (vertical)
     TitlePosition(box.Top).
     ContentAlign(box.Center).
     Color(box.Cyan).
@@ -363,6 +364,18 @@ b.VPadding(py)    // vertical only
 
 Setting negative padding causes `Render` to return an error.
 
+### Margin
+
+Margin adds space outside the box borders — horizontal margin prepends spaces to every line, vertical margin adds blank lines above and below.
+
+```go
+b.Margin(mx, my) // horizontal (mx) and vertical (my) margin
+b.HMargin(mx)    // horizontal only
+b.VMargin(my)    // vertical only
+```
+
+Setting negative margin causes `Render` to return an error.
+
 ### Wrapping
 
 ```go
@@ -424,6 +437,7 @@ fmt.Println(out)
 - The `TitleAlign` or `ContentAlign` is invalid
 - The wrap limit is negative
 - Padding is negative
+- Margin is negative
 - A multiline title is used with a non‑`Inside` title position
 - Any configured colors are invalid
 - Terminal width detection fails when needed for wrapping

--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ Setting negative margin causes `Render` to return an error.
 ### Wrapping
 
 ```go
-b.WrapContent(true)       // enable wrapping (default width: 2/3 of terminal)
+b.WrapContent(true)       // enable wrapping (default: 2/3 of terminal width, minus any HMargin)
 b.WrapLimit(40)           // set explicit wrap width (enables wrapping)
 b.WrapContent(false)      // disable wrapping
 ```

--- a/box.go
+++ b/box.go
@@ -42,6 +42,8 @@ type Box struct {
 type config struct {
 	py            int           // Vertical padding.
 	px            int           // Horizontal padding.
+	my            int           // Vertical margin.
+	mx            int           // Horizontal margin.
 	contentAlign  AlignType     // Alignment for content inside the box.
 	style         BoxStyle      // Active box style preset.
 	titlePos      TitlePosition // Where the title, if any, is rendered.
@@ -88,6 +90,25 @@ func (b *Box) HPadding(px int) *Box {
 // VPadding sets vertical padding (top and bottom).
 func (b *Box) VPadding(py int) *Box {
 	b.py = py
+	return b
+}
+
+// Margin sets horizontal (mx) and vertical (my) outer margin around the box.
+func (b *Box) Margin(mx, my int) *Box {
+	b.mx = mx
+	b.my = my
+	return b
+}
+
+// HMargin sets horizontal outer margin (left spacing).
+func (b *Box) HMargin(mx int) *Box {
+	b.mx = mx
+	return b
+}
+
+// VMargin sets vertical outer margin (blank lines above and below).
+func (b *Box) VMargin(my int) *Box {
+	b.my = my
 	return b
 }
 
@@ -429,6 +450,9 @@ func (b *Box) Render(title, content string) (string, error) {
 			return "", fmt.Errorf("invalid Box style %s", b.style)
 		}
 	}
+	if b.mx < 0 || b.my < 0 {
+		return "", fmt.Errorf("margin cannot be negative")
+	}
 
 	content, err := b.wrapContent(content)
 	if err != nil {
@@ -478,5 +502,23 @@ func (b *Box) Render(title, content string) (string, error) {
 	sb.WriteString(bottomBar)
 	sb.WriteString("\n")
 
-	return sb.String(), nil
+	out := sb.String()
+	if b.mx > 0 || b.my > 0 {
+		prefix := strings.Repeat(" ", b.mx)
+		sb.Reset()
+		for range b.my {
+			sb.WriteByte('\n')
+		}
+		for line := range strings.SplitSeq(strings.TrimRight(out, "\n"), "\n") {
+			sb.WriteString(prefix)
+			sb.WriteString(line)
+			sb.WriteByte('\n')
+		}
+		for range b.my {
+			sb.WriteByte('\n')
+		}
+		out = sb.String()
+	}
+
+	return out, nil
 }

--- a/box.go
+++ b/box.go
@@ -494,6 +494,12 @@ func (b *Box) Render(title, content string) (string, error) {
 	}
 	texts = append(texts, vertPadding...)
 
+	out := b.assembleBoxString(topBar, bottomBar, texts)
+	return b.applyMargin(out), nil
+}
+
+// assembleBoxString combines the top bar, content lines, and bottom bar into the final box string.
+func (b *Box) assembleBoxString(topBar, bottomBar string, texts []string) string {
 	var sb strings.Builder
 	sb.WriteString(topBar)
 	sb.WriteString("\n")
@@ -501,24 +507,26 @@ func (b *Box) Render(title, content string) (string, error) {
 	sb.WriteString("\n")
 	sb.WriteString(bottomBar)
 	sb.WriteString("\n")
+	return sb.String()
+}
 
-	out := sb.String()
-	if b.mx > 0 || b.my > 0 {
-		prefix := strings.Repeat(" ", b.mx)
-		sb.Reset()
-		for range b.my {
-			sb.WriteByte('\n')
-		}
-		for line := range strings.SplitSeq(strings.TrimRight(out, "\n"), "\n") {
-			sb.WriteString(prefix)
-			sb.WriteString(line)
-			sb.WriteByte('\n')
-		}
-		for range b.my {
-			sb.WriteByte('\n')
-		}
-		out = sb.String()
+// applyMargin adds the configured horizontal and vertical margins to the rendered box string.
+func (b *Box) applyMargin(out string) string {
+	if b.mx == 0 && b.my == 0 {
+		return out
 	}
-
-	return out, nil
+	prefix := strings.Repeat(" ", b.mx)
+	var sb strings.Builder
+	for range b.my {
+		sb.WriteByte('\n')
+	}
+	for line := range strings.SplitSeq(strings.TrimRight(out, "\n"), "\n") {
+		sb.WriteString(prefix)
+		sb.WriteString(line)
+		sb.WriteByte('\n')
+	}
+	for range b.my {
+		sb.WriteByte('\n')
+	}
+	return sb.String()
 }

--- a/box.go
+++ b/box.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/x/ansi"
-	"github.com/charmbracelet/x/term"
 	"github.com/huandu/xstrings"
 	"github.com/mattn/go-runewidth"
 )
@@ -223,9 +222,11 @@ func (b *Box) TitlePosition(pos TitlePosition) *Box {
 
 // WrapContent enables or disables automatic wrapping of content.
 //
-// When enabled, content is wrapped to fit roughly two-thirds of the terminal
-// width by default. For custom limits or non-TTY outputs, use WrapLimit
-// instead.
+// When enabled, content is wrapped to fit roughly two-thirds of the available
+// terminal width by default. If a horizontal margin is set, it is subtracted
+// from the terminal width before computing the wrap limit, so the rendered box
+// stays within the terminal. For custom limits or non-TTY outputs, use
+// WrapLimit instead.
 func (b *Box) WrapContent(allow bool) *Box {
 	b.allowWrapping = allow
 	return b
@@ -285,12 +286,13 @@ func (b *Box) wrapContent(content string) (string, error) {
 	if !isTTY(os.Stdout.Fd()) {
 		return "", fmt.Errorf("cannot determine terminal width; use WrapLimit to set an explicit wrap limit when wrapping on non-TTY outputs")
 	}
-	width, _, err := term.GetSize(os.Stdout.Fd())
+	width, _, err := getTermSize(os.Stdout.Fd())
 	if err != nil {
 		return "", fmt.Errorf("cannot determine terminal width: %v", err)
 	}
-	// Use 2/3 of terminal width as default wrapping limit
-	wrapWidth := max(2*width/defaultWrapDivisor, minWrapWidth)
+	// Use 2/3 of available width as default wrapping limit.
+	// Subtract mx so the margin added by applyMargin doesn't push lines past the terminal edge.
+	wrapWidth := max(2*max(width-b.mx, 0)/defaultWrapDivisor, minWrapWidth)
 	return ansi.Wrap(content, wrapWidth, ""), nil
 }
 
@@ -494,12 +496,12 @@ func (b *Box) Render(title, content string) (string, error) {
 	}
 	texts = append(texts, vertPadding...)
 
-	out := b.assembleBoxString(topBar, bottomBar, texts)
+	out := assembleBoxString(topBar, bottomBar, texts)
 	return b.applyMargin(out), nil
 }
 
 // assembleBoxString combines the top bar, content lines, and bottom bar into the final box string.
-func (b *Box) assembleBoxString(topBar, bottomBar string, texts []string) string {
+func assembleBoxString(topBar, bottomBar string, texts []string) string {
 	var sb strings.Builder
 	sb.WriteString(topBar)
 	sb.WriteString("\n")
@@ -518,14 +520,16 @@ func (b *Box) applyMargin(out string) string {
 	prefix := strings.Repeat(" ", b.mx)
 	var sb strings.Builder
 	for range b.my {
+		sb.WriteString(prefix)
 		sb.WriteByte('\n')
 	}
-	for line := range strings.SplitSeq(strings.TrimRight(out, "\n"), "\n") {
+	for line := range strings.SplitSeq(strings.TrimSuffix(out, "\n"), "\n") {
 		sb.WriteString(prefix)
 		sb.WriteString(line)
 		sb.WriteByte('\n')
 	}
 	for range b.my {
+		sb.WriteString(prefix)
 		sb.WriteByte('\n')
 	}
 	return sb.String()

--- a/box_render_test.go
+++ b/box_render_test.go
@@ -732,6 +732,68 @@ func TestRenderBoxCustomGlyphsWithoutNewBoxMethod(t *testing.T) {
 	}
 }
 
+func TestRenderMargin(t *testing.T) {
+	const title, content = "Title", "Content"
+
+	// Horizontal margin: every non-empty line must be prefixed with mx spaces.
+	out, err := NewBox().Style(Single).HMargin(4).Render(title, content)
+	if err != nil {
+		t.Fatalf("HMargin: unexpected error: %v", err)
+	}
+	for _, line := range strings.Split(strings.TrimRight(out, "\n"), "\n") {
+		if !strings.HasPrefix(line, "    ") {
+			t.Errorf("HMargin: line missing 4-space prefix: %q", line)
+		}
+	}
+
+	// Vertical margin: output must start and end with my blank lines.
+	out, err = NewBox().Style(Single).VMargin(2).Render(title, content)
+	if err != nil {
+		t.Fatalf("VMargin: unexpected error: %v", err)
+	}
+	if !strings.HasPrefix(out, "\n\n") {
+		t.Errorf("VMargin: output does not start with 2 blank lines: %q", out[:min(len(out), 10)])
+	}
+	if !strings.HasSuffix(strings.TrimRight(out, ""), "\n\n") {
+		t.Errorf("VMargin: output does not end with 2 blank lines")
+	}
+
+	// Margin(mx, my): combines both.
+	out, err = NewBox().Style(Single).Margin(3, 1).Render(title, content)
+	if err != nil {
+		t.Fatalf("Margin: unexpected error: %v", err)
+	}
+	if !strings.HasPrefix(out, "\n") {
+		t.Errorf("Margin: output does not start with blank line")
+	}
+	for _, line := range strings.Split(strings.TrimRight(out, "\n"), "\n") {
+		if line != "" && !strings.HasPrefix(line, "   ") {
+			t.Errorf("Margin: line missing 3-space prefix: %q", line)
+		}
+	}
+
+	// Zero margin produces the same output as no margin.
+	plain, err := NewBox().Style(Single).Render(title, content)
+	if err != nil {
+		t.Fatalf("plain: unexpected error: %v", err)
+	}
+	zero, err := NewBox().Style(Single).Margin(0, 0).Render(title, content)
+	if err != nil {
+		t.Fatalf("Margin(0,0): unexpected error: %v", err)
+	}
+	if plain != zero {
+		t.Errorf("Margin(0,0) should produce identical output to no margin")
+	}
+
+	// Negative margin must error.
+	if _, err := NewBox().Style(Single).Margin(-1, 0).Render(title, content); err == nil {
+		t.Errorf("expected error for negative horizontal margin, got nil")
+	}
+	if _, err := NewBox().Style(Single).Margin(0, -1).Render(title, content); err == nil {
+		t.Errorf("expected error for negative vertical margin, got nil")
+	}
+}
+
 func findLineContainingTitle(lines []string, title string) string {
 	for _, line := range lines {
 		if strings.Contains(line, title) {

--- a/box_render_test.go
+++ b/box_render_test.go
@@ -1,6 +1,7 @@
 package box
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -154,6 +155,7 @@ func TestBoxCopy(t *testing.T) {
 	t.Run("independent copies", func(t *testing.T) {
 		original := NewBox().
 			Padding(1, 2).
+			Margin(3, 4).
 			Color(Red).
 			TitleColor(Blue).
 			ContentColor(Yellow).
@@ -171,12 +173,20 @@ func TestBoxCopy(t *testing.T) {
 			t.Fatalf("Copy should return a distinct pointer")
 		}
 
-		clone.Color(Green).Padding(5, 6).TitlePosition(Bottom).TopLeft("*")
+		// Margin fields must be copied.
+		if clone.mx != 3 || clone.my != 4 {
+			t.Fatalf("expected cloned margin (3,4), got (%d,%d)", clone.mx, clone.my)
+		}
+
+		clone.Color(Green).Padding(5, 6).Margin(10, 11).TitlePosition(Bottom).TopLeft("*")
 		if original.color != Red {
 			t.Fatalf("expected original color to remain Red, got %q", original.color)
 		}
 		if original.px != 1 || original.py != 2 {
 			t.Fatalf("expected original padding (1,2), got (%d,%d)", original.px, original.py)
+		}
+		if original.mx != 3 || original.my != 4 {
+			t.Fatalf("expected original margin (3,4) after mutating clone, got (%d,%d)", original.mx, original.my)
 		}
 		if original.titlePos != Top {
 			t.Fatalf("expected original title position to stay Top, got %v", original.titlePos)
@@ -518,6 +528,88 @@ func TestRenderNonTTYLWrapContent(t *testing.T) {
 	}
 }
 
+func TestRenderWrapContentWithMarginFitsTerminal(t *testing.T) {
+	const termWidth = 80
+
+	oldIsTTY := isTTY
+	oldGetTermSize := getTermSize
+	defer func() {
+		isTTY = oldIsTTY
+		getTermSize = oldGetTermSize
+	}()
+	isTTY = func(fd uintptr) bool { return true }
+	getTermSize = func(fd uintptr) (int, int, error) { return termWidth, 24, nil }
+
+	content := strings.Repeat("Box CLI Maker ", 40)
+	margins := []int{0, 10, 20, 25, 30, termWidth/3 - 1, termWidth / 3, termWidth/3 + 1}
+
+	for _, mx := range margins {
+		t.Run(fmt.Sprintf("HMargin%d", mx), func(t *testing.T) {
+			b := NewBox().Style(Single).Padding(2, 0).HMargin(mx).WrapContent(true)
+			out, err := b.Render("Demo", content)
+			if err != nil {
+				t.Fatalf("HMargin(%d): unexpected error: %v", mx, err)
+			}
+			for line := range strings.SplitSeq(strings.TrimRight(out, "\n"), "\n") {
+				if w := runewidth.StringWidth(ansi.Strip(line)); w > termWidth {
+					t.Errorf("HMargin(%d): line exceeds terminal width %d (got %d): %q", mx, termWidth, w, line)
+				}
+			}
+		})
+	}
+}
+
+// TestRenderWrapLimitMarginOverflowRegression verifies the fix for the bug
+// where WrapContent used the full terminal width without subtracting HMargin.
+// The old workaround (WrapLimit set to 2/3 of terminal) overflows when HMargin
+// is large; WrapContent(true) must not.
+func TestRenderWrapLimitMarginOverflowRegression(t *testing.T) {
+	const termWidth = 80
+	largeMx := termWidth/3 + 1  // 27: large enough to cause overflow before the fix
+	oldWrapWidth := 2 * termWidth / 3 // 53: what wrapContent used to compute (ignoring margin)
+
+	oldIsTTY := isTTY
+	oldGetTermSize := getTermSize
+	defer func() {
+		isTTY = oldIsTTY
+		getTermSize = oldGetTermSize
+	}()
+	isTTY = func(fd uintptr) bool { return true }
+	getTermSize = func(fd uintptr) (int, int, error) { return termWidth, 24, nil }
+
+	content := strings.Repeat("Box CLI Maker ", 40)
+
+	// Old behaviour: WrapLimit(2/3 of terminal) ignores margin → overflows.
+	before := NewBox().Style(Single).Padding(2, 0).HMargin(largeMx).WrapLimit(oldWrapWidth)
+	outBefore, err := before.Render("Overflow Demo", content)
+	if err != nil {
+		t.Fatalf("before: unexpected error: %v", err)
+	}
+	overflows := false
+	for line := range strings.SplitSeq(strings.TrimRight(outBefore, "\n"), "\n") {
+		if runewidth.StringWidth(ansi.Strip(line)) > termWidth {
+			overflows = true
+			break
+		}
+	}
+	if !overflows {
+		t.Errorf("expected WrapLimit(%d)+HMargin(%d) to overflow a %d-col terminal, but no line exceeded it",
+			oldWrapWidth, largeMx, termWidth)
+	}
+
+	// Fixed behaviour: WrapContent(true) subtracts margin before computing wrap width → fits.
+	after := NewBox().Style(Single).Padding(2, 0).HMargin(largeMx).WrapContent(true)
+	outAfter, err := after.Render("Overflow Demo", content)
+	if err != nil {
+		t.Fatalf("after: unexpected error: %v", err)
+	}
+	for line := range strings.SplitSeq(strings.TrimRight(outAfter, "\n"), "\n") {
+		if w := runewidth.StringWidth(ansi.Strip(line)); w > termWidth {
+			t.Errorf("after fix: line exceeds terminal width %d (got %d): %q", termWidth, w, line)
+		}
+	}
+}
+
 func TestRenderNegativePadding(t *testing.T) {
 	// Horizontal padding < 0.
 	b := NewBox().Padding(-1, 1).Style(Single)
@@ -735,12 +827,12 @@ func TestRenderBoxCustomGlyphsWithoutNewBoxMethod(t *testing.T) {
 func TestRenderMargin(t *testing.T) {
 	const title, content = "Title", "Content"
 
-	// Horizontal margin: every non-empty line must be prefixed with mx spaces.
+	// Horizontal margin: every line (including blank vertical-margin lines) must be prefixed.
 	out, err := NewBox().Style(Single).HMargin(4).Render(title, content)
 	if err != nil {
 		t.Fatalf("HMargin: unexpected error: %v", err)
 	}
-	for _, line := range strings.Split(strings.TrimRight(out, "\n"), "\n") {
+	for line := range strings.SplitSeq(strings.TrimRight(out, "\n"), "\n") {
 		if !strings.HasPrefix(line, "    ") {
 			t.Errorf("HMargin: line missing 4-space prefix: %q", line)
 		}
@@ -754,20 +846,22 @@ func TestRenderMargin(t *testing.T) {
 	if !strings.HasPrefix(out, "\n\n") {
 		t.Errorf("VMargin: output does not start with 2 blank lines: %q", out[:min(len(out), 10)])
 	}
-	if !strings.HasSuffix(strings.TrimRight(out, ""), "\n\n") {
-		t.Errorf("VMargin: output does not end with 2 blank lines")
+	// 2 blank lines = 2 extra newlines after the final box line's own newline → 3 total.
+	nTrailing := len(out) - len(strings.TrimRight(out, "\n"))
+	if nTrailing != 3 {
+		t.Errorf("VMargin: expected 3 trailing newlines (2 blank lines), got %d", nTrailing)
 	}
 
-	// Margin(mx, my): combines both.
+	// Margin(mx, my): combines both; blank vertical-margin lines carry the horizontal prefix.
 	out, err = NewBox().Style(Single).Margin(3, 1).Render(title, content)
 	if err != nil {
 		t.Fatalf("Margin: unexpected error: %v", err)
 	}
-	if !strings.HasPrefix(out, "\n") {
-		t.Errorf("Margin: output does not start with blank line")
+	if !strings.HasPrefix(out, "   \n") {
+		t.Errorf("Margin: output does not start with prefixed blank line, got %q", out[:min(len(out), 10)])
 	}
-	for _, line := range strings.Split(strings.TrimRight(out, "\n"), "\n") {
-		if line != "" && !strings.HasPrefix(line, "   ") {
+	for line := range strings.SplitSeq(strings.TrimRight(out, "\n"), "\n") {
+		if !strings.HasPrefix(line, "   ") {
 			t.Errorf("Margin: line missing 3-space prefix: %q", line)
 		}
 	}
@@ -805,9 +899,9 @@ func findLineContainingTitle(lines []string, title string) string {
 
 func titleStartColumn(line, title string) int {
 	stripped := ansi.Strip(line)
-	idx := strings.Index(stripped, title)
-	if idx == -1 {
+	before, _, ok := strings.Cut(stripped, title)
+	if !ok {
 		return -1
 	}
-	return runewidth.StringWidth(stripped[:idx])
+	return runewidth.StringWidth(before)
 }

--- a/box_render_test.go
+++ b/box_render_test.go
@@ -173,7 +173,6 @@ func TestBoxCopy(t *testing.T) {
 			t.Fatalf("Copy should return a distinct pointer")
 		}
 
-		// Margin fields must be copied.
 		if clone.mx != 3 || clone.my != 4 {
 			t.Fatalf("expected cloned margin (3,4), got (%d,%d)", clone.mx, clone.my)
 		}
@@ -565,7 +564,7 @@ func TestRenderWrapContentWithMarginFitsTerminal(t *testing.T) {
 // is large; WrapContent(true) must not.
 func TestRenderWrapLimitMarginOverflowRegression(t *testing.T) {
 	const termWidth = 80
-	largeMx := termWidth/3 + 1  // 27: large enough to cause overflow before the fix
+	largeMx := termWidth/3 + 1        // 27: large enough to cause overflow before the fix
 	oldWrapWidth := 2 * termWidth / 3 // 53: what wrapContent used to compute (ignoring margin)
 
 	oldIsTTY := isTTY

--- a/doc.go
+++ b/doc.go
@@ -89,8 +89,10 @@
 // # Wrapping
 //
 // WrapContent enables or disables automatic wrapping of the content. By
-// default, when wrapping is enabled, the box width is based on two‑thirds of
-// the terminal width. WrapLimit can be used to set an explicit maximum width.
+// default, when wrapping is enabled, the wrap limit is two‑thirds of the
+// available terminal width. If a horizontal margin is set, it is subtracted
+// from the terminal width first so the rendered box stays within the terminal.
+// WrapLimit can be used to set an explicit maximum width.
 //
 // # Colors
 //

--- a/doc.go
+++ b/doc.go
@@ -71,6 +71,21 @@
 //	box.Center
 //	box.Right
 //
+// # Padding
+//
+// Padding adds space inside the box borders between the content and the edges.
+// Horizontal padding adds spaces on the left and right of each line. Vertical
+// padding adds blank lines above and below the content. Use Padding to set
+// both at once, or HPadding / VPadding to set each independently. Negative
+// padding causes Render to return an error.
+//
+// # Margin
+//
+// Margin adds space outside the box borders. Horizontal margin prepends spaces
+// to every rendered line. Vertical margin adds blank lines above and below the
+// box. Use Margin to set both at once, or HMargin / VMargin to set each
+// independently. Negative margin causes Render to return an error.
+//
 // # Wrapping
 //
 // WrapContent enables or disables automatic wrapping of the content. By
@@ -87,9 +102,9 @@
 // # Errors
 //
 // Render returns an error if the style or title position is invalid, the wrap
-// limit or padding is negative, a multiline title is used with a non‑Inside
-// title position, any configured colors are invalid, or the terminal width
-// cannot be determined. MustRender is a convenience wrapper that panics on
+// limit, padding, or margin is negative, a multiline title is used with a
+// non‑Inside title position, any configured colors are invalid, or the
+// terminal width cannot be determined. MustRender is a convenience wrapper that panics on
 // error.
 //
 // # Copying

--- a/examples/content_wrap/main.go
+++ b/examples/content_wrap/main.go
@@ -9,9 +9,11 @@ import (
 
 func main() {
 	b := box.NewBox().Padding(2, 0).
+		Margin(5, 2).
 		Style(box.Single).
 		Color(box.Green).
 		TitlePosition(box.Top).
+		TitleAlign(box.Center).
 		WrapContent(true)
 		// Provide your limit with WrapLimit if needed
 

--- a/util.go
+++ b/util.go
@@ -15,6 +15,12 @@ import (
 // It is defined as a variable to allow mocking in tests.
 var isTTY = term.IsTerminal
 
+// getTermSize returns the dimensions of the terminal attached to fd.
+// It is defined as a variable to allow mocking in tests.
+var getTermSize = func(fd uintptr) (int, int, error) {
+	return term.GetSize(fd)
+}
+
 // expandedLine stores a tab-expanded line, and its visible length.
 type expandedLine struct {
 	line string // tab-expanded line
@@ -170,7 +176,6 @@ func (b *Box) formatLine(lines2 []expandedLine, longestLine, titleLen int, sideM
 	for i, line := range lines2 {
 		length := line.len
 
-		// Use later
 		var space, oddSpace string
 
 		// compute stripped width once

--- a/util.go
+++ b/util.go
@@ -17,9 +17,7 @@ var isTTY = term.IsTerminal
 
 // getTermSize returns the dimensions of the terminal attached to fd.
 // It is defined as a variable to allow mocking in tests.
-var getTermSize = func(fd uintptr) (int, int, error) {
-	return term.GetSize(fd)
-}
+var getTermSize = term.GetSize
 
 // expandedLine stores a tab-expanded line, and its visible length.
 type expandedLine struct {


### PR DESCRIPTION
Implements https://github.com/box-cli-maker/box-cli-maker/issues/60

This PR adds margin support for rendering boxes. Horizontal margin adds the left outer spacing. Vertical margin adds newlines.

### API Design 

```go
b.Margin(mx, my) // horizontal (mx) and vertical (my) margin
b.HMargin(mx)    // horizontal only
b.VMargin(my)    // vertical only
```

The content wrap example has been changed to showcase how margins play a role in box rendering


#### Before Magin

<img width="1584" height="864" alt="image" src="https://github.com/user-attachments/assets/f8511f29-d7a0-4f37-b48d-6c1ca20fca77" />


#### After Margin

`Margin(5, 2)` which adds 5 spaces from the left and 2 newlines before the box.

<img width="1919" height="950" alt="image" src="https://github.com/user-attachments/assets/0d762af6-08d1-432f-ac46-1c606d9994ad" />
