### PR TITLE
feat(box): add per-side border colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Box CLI Maker is a Go library for rendering highly customizable boxes in the ter
 - Color support with:
   - First 16 ANSI color names
   - `#RGB`, `#RRGGBB`, `rgb:RRRR/GGGG/BBBB`, `rgba:RRRR/GGGG/BBBB/AAAA`
+- Independent top, right, bottom, and left border colors
 - Unicode and emoji support with proper width handling
 - Explicit errors from `Render`, plus `MustRender` for panic‑on‑error 
 
@@ -392,7 +393,8 @@ Colors can be applied to:
 
 - Title: `TitleColor`
 - Content: `ContentColor`
-- Border: `Color`
+- Complete border: `Color`
+- Individual borders: `TopBorderColor`, `RightBorderColor`, `BottomBorderColor`, and `LeftBorderColor`
 
 Accepted formats:
 
@@ -416,6 +418,20 @@ b.TitleColor(box.BrightYellow)
 b.ContentColor("#00FF00")
 b.Color("rgb:0000/ffff/0000")
 ```
+
+Use `Color` as a fallback and override any individual border:
+
+```go
+b.Color(box.White).
+  TopBorderColor(box.Red).
+  RightBorderColor(box.Green).
+  BottomBorderColor(box.Blue).
+  LeftBorderColor(box.Yellow)
+```
+
+Top and bottom border colors include their respective corner glyphs. An
+individual border color takes precedence over `Color`; pass an empty string to
+clear an override and use the fallback again.
 
 Invalid colors cause `Render` to return an error.
 
@@ -459,6 +475,7 @@ The [examples](examples) directory contains small, focused programs that showcas
 - `title_alignments` – compare `Left`, `Center`, and `Right` title alignment.
 - `box_styles` – render all built‑in border styles and colors.
 - `custom_box` – build boxes using fully custom corner/edge glyphs.
+- `custom_border_colors` – give each side of a box a different color.
 - `ansi_styles_and_links` – use bold/underline/blink/strikethrough and OSC 8 hyperlinks.
 - `colors_and_unicode` – mix hex/ANSI colors with CJK, emoji, and wrapping.
 - `ansi_art` – render more decorative/"artistic" boxes.

--- a/box.go
+++ b/box.go
@@ -10,10 +10,11 @@ import (
 )
 
 const (
-	// 1 = separator, 2 = spacing, 3 = line; 4 = oddSpace; 5 = space; 6 = sideMargin
-	centerAlign = "%[1]s%[2]s%[3]s%[4]s%[2]s%[1]s"
-	leftAlign   = "%[1]s%[6]s%[3]s%[4]s%[2]s%[5]s%[1]s"
-	rightAlign  = "%[1]s%[2]s%[4]s%[5]s%[3]s%[6]s%[1]s"
+	// 1 = left separator, 2 = spacing, 3 = line; 4 = oddSpace;
+	// 5 = space; 6 = sideMargin; 7 = right separator
+	centerAlign = "%[1]s%[2]s%[3]s%[4]s%[2]s%[7]s"
+	leftAlign   = "%[1]s%[6]s%[3]s%[4]s%[2]s%[5]s%[7]s"
+	rightAlign  = "%[1]s%[2]s%[4]s%[5]s%[3]s%[6]s%[7]s"
 
 	defaultWrapDivisor = 3  // 2/3 of terminal width
 	minWrapWidth       = 20 // Minimum width to wrap content
@@ -48,7 +49,11 @@ type config struct {
 	titleAlign    AlignType     // Alignment for the title based on TitlePosition.
 	titleColor    string        // ANSI color (or hex code) for the title.
 	contentColor  string        // ANSI color (or hex code) for the content.
-	color         string        // ANSI color (or hex code) for the box chrome.
+	color         string        // Fallback ANSI color (or hex code) for all box borders.
+	topColor      string        // Optional color override for the top border.
+	rightColor    string        // Optional color override for the right border.
+	bottomColor   string        // Optional color override for the bottom border.
+	leftColor     string        // Optional color override for the left border.
 	allowWrapping bool          // Whether long content may wrap.
 	wrappingLimit int           // Custom wrap width when wrapping is enabled.
 	styleSet      bool          // Tracks if a style preset has already been applied.
@@ -208,6 +213,42 @@ func (b *Box) ContentColor(color string) *Box {
 // Invalid colors cause Render to return an error.
 func (b *Box) Color(color string) *Box {
 	b.color = color
+	return b
+}
+
+// TopBorderColor sets the color used for the complete top border, including
+// its corners. It overrides Color for that border.
+//
+// Accepts the same color formats as Color. An empty value clears the override.
+func (b *Box) TopBorderColor(color string) *Box {
+	b.topColor = color
+	return b
+}
+
+// RightBorderColor sets the color used for the right vertical border. It
+// overrides Color for that border.
+//
+// Accepts the same color formats as Color. An empty value clears the override.
+func (b *Box) RightBorderColor(color string) *Box {
+	b.rightColor = color
+	return b
+}
+
+// BottomBorderColor sets the color used for the complete bottom border,
+// including its corners. It overrides Color for that border.
+//
+// Accepts the same color formats as Color. An empty value clears the override.
+func (b *Box) BottomBorderColor(color string) *Box {
+	b.bottomColor = color
+	return b
+}
+
+// LeftBorderColor sets the color used for the left vertical border. It
+// overrides Color for that border.
+//
+// Accepts the same color formats as Color. An empty value clears the override.
+func (b *Box) LeftBorderColor(color string) *Box {
+	b.leftColor = color
 	return b
 }
 
@@ -412,10 +453,12 @@ func (b *Box) buildAndColorBars(title string, lay boxLayout) (string, string, er
 	}
 
 	var err error
-	if topBar, err = applyColor(topBar, b.color); err != nil {
+	topColor := borderColor(b.topColor, b.color)
+	bottomColor := borderColor(b.bottomColor, b.color)
+	if topBar, err = applyColor(topBar, topColor); err != nil {
 		return "", "", err
 	}
-	if bottomBar, err = applyColor(bottomBar, b.color); err != nil {
+	if bottomBar, err = applyColor(bottomBar, bottomColor); err != nil {
 		return "", "", err
 	}
 

--- a/box_render_test.go
+++ b/box_render_test.go
@@ -1129,6 +1129,130 @@ func TestRenderANSIColoredContentWidth(t *testing.T) {
 	}
 }
 
+func TestRenderCustomBorderColors(t *testing.T) {
+	b := NewBox().
+		Style(Classic).
+		Padding(1, 1).
+		Color(White).
+		TopBorderColor(Red).
+		RightBorderColor(Green).
+		BottomBorderColor(Blue).
+		LeftBorderColor(Yellow)
+
+	out, err := b.Render("", "content")
+	if err != nil {
+		t.Fatalf("Render returned error: %v", err)
+	}
+	lines := strings.Split(strings.TrimSuffix(out, "\n"), "\n")
+	if len(lines) != 5 {
+		t.Fatalf("expected 5 lines, got %d:\n%s", len(lines), out)
+	}
+
+	wantTop, err := applyColor(ansi.Strip(lines[0]), Red)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lines[0] != wantTop {
+		t.Errorf("top border does not use TopBorderColor:\ngot  %q\nwant %q", lines[0], wantTop)
+	}
+
+	wantBottom, err := applyColor(ansi.Strip(lines[len(lines)-1]), Blue)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lines[len(lines)-1] != wantBottom {
+		t.Errorf("bottom border does not use BottomBorderColor:\ngot  %q\nwant %q", lines[len(lines)-1], wantBottom)
+	}
+
+	wantLeft, err := applyColor("|", Yellow)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantRight, err := applyColor("|", Green)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i, line := range lines[1 : len(lines)-1] {
+		if !strings.HasPrefix(line, wantLeft) {
+			t.Errorf("interior line %d does not use LeftBorderColor: %q", i, line)
+		}
+		if !strings.HasSuffix(line, wantRight) {
+			t.Errorf("interior line %d does not use RightBorderColor: %q", i, line)
+		}
+	}
+}
+
+func TestRenderCustomBorderColorsFallbackAndClear(t *testing.T) {
+	base := NewBox().Style(Single).Padding(1, 1).Color(Cyan)
+	want, err := base.Render("Title", "content")
+	if err != nil {
+		t.Fatalf("fallback Render returned error: %v", err)
+	}
+
+	got, err := base.Copy().
+		TopBorderColor(Red).
+		RightBorderColor(Green).
+		BottomBorderColor(Blue).
+		LeftBorderColor(Yellow).
+		TopBorderColor("").
+		RightBorderColor("").
+		BottomBorderColor("").
+		LeftBorderColor("").
+		Render("Title", "content")
+	if err != nil {
+		t.Fatalf("cleared override Render returned error: %v", err)
+	}
+	if got != want {
+		t.Errorf("clearing side overrides did not restore Color fallback:\ngot:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestRenderCustomBorderColorsPreserveBorderTitleColor(t *testing.T) {
+	const title = "Custom title"
+	b := NewBox().
+		Style(Single).
+		TitlePosition(Top).
+		TopBorderColor(Red).
+		TitleColor(BrightYellow)
+
+	out, err := b.Render(title, "content")
+	if err != nil {
+		t.Fatalf("Render returned error: %v", err)
+	}
+	top := strings.SplitN(out, "\n", 2)[0]
+	styledTitle, err := applyColor(title, BrightYellow)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(top, styledTitle) {
+		t.Errorf("top border did not preserve TitleColor:\ngot title bar %q\nwant it to contain %q", top, styledTitle)
+	}
+}
+
+func TestRenderInvalidCustomBorderColors(t *testing.T) {
+	tests := []struct {
+		name      string
+		configure func(*Box) *Box
+	}{
+		{"top", func(b *Box) *Box { return b.TopBorderColor("invalid") }},
+		{"right", func(b *Box) *Box { return b.RightBorderColor("invalid") }},
+		{"bottom", func(b *Box) *Box { return b.BottomBorderColor("invalid") }},
+		{"left", func(b *Box) *Box { return b.LeftBorderColor("invalid") }},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := tc.configure(NewBox()).Render("Title", "content")
+			if err == nil {
+				t.Fatal("expected invalid custom border color to return an error")
+			}
+			if !strings.Contains(err.Error(), "unable to parse color") {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
 func findLineContainingTitle(lines []string, title string) string {
 	for _, line := range lines {
 		if strings.Contains(line, title) {

--- a/doc.go
+++ b/doc.go
@@ -96,10 +96,16 @@
 //
 // # Colors
 //
-// TitleColor, ContentColor, and Color accept either one of the first 16 ANSI
-// color name constants (e.g. box.Green, box.BrightRed) or a
+// TitleColor, ContentColor, Color, and the per-side border color methods accept
+// either one of the first 16 ANSI color name constants (e.g. box.Green,
+// box.BrightRed) or a
 // #RGB / #RRGGBB / rgb:RRRR/GGGG/BBBB / rgba:RRRR/GGGG/BBBB/AAAA value.
 // Invalid colors cause Render to return an error.
+//
+// Color sets the fallback for the complete border. TopBorderColor,
+// RightBorderColor, BottomBorderColor, and LeftBorderColor override that
+// fallback for one side. Top and bottom colors include their respective corner
+// glyphs. Passing an empty string to a per-side method clears its override.
 //
 // # Errors
 //

--- a/examples/custom_border_colors/main.go
+++ b/examples/custom_border_colors/main.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"fmt"
+
+	box "github.com/box-cli-maker/box-cli-maker/v3"
+)
+
+func main() {
+	b := box.NewBox().
+		Style(box.Round).
+		Padding(2, 1).
+		Color(box.White).
+		TopBorderColor(box.Red).
+		RightBorderColor(box.Green).
+		BottomBorderColor(box.Blue).
+		LeftBorderColor(box.Yellow).
+		TitleColor(box.BrightMagenta)
+
+	fmt.Print(b.MustRender("Custom border colors", "Each side has its own color."))
+}

--- a/util.go
+++ b/util.go
@@ -32,14 +32,18 @@ func (b *Box) addVertPadding(innerWidth int) ([]string, error) {
 		innerWidth = 0
 	}
 	padding := strings.Repeat(" ", innerWidth)
-	vertical, err := applyColor(b.vertical, b.color)
+	left, err := applyColor(b.vertical, borderColor(b.leftColor, b.color))
+	if err != nil {
+		return nil, err
+	}
+	right, err := applyColor(b.vertical, borderColor(b.rightColor, b.color))
 	if err != nil {
 		return nil, err
 	}
 
 	texts := make([]string, b.py)
 	for i := range texts {
-		texts[i] = vertical + padding + vertical
+		texts[i] = left + padding + right
 	}
 
 	return texts, nil
@@ -211,7 +215,11 @@ func (b *Box) buildTitledBar(left, right string, lineWidth int, title string, al
 
 // formatLine formats the line according to the information passed.
 func (b *Box) formatLine(lines2 []expandedLine, longestLine, titleLen int, sideMargin, title string, texts []string) ([]string, error) {
-	sep, err := applyColor(b.vertical, b.color)
+	left, err := applyColor(b.vertical, borderColor(b.leftColor, b.color))
+	if err != nil {
+		return nil, err
+	}
+	right, err := applyColor(b.vertical, borderColor(b.rightColor, b.color))
 	if err != nil {
 		return nil, err
 	}
@@ -252,7 +260,7 @@ func (b *Box) formatLine(lines2 []expandedLine, longestLine, titleLen int, sideM
 			return nil, err
 		}
 
-		formatted := fmt.Sprintf(format, sep, spacing, line.line, oddSpace, space, sideMargin)
+		formatted := fmt.Sprintf(format, left, spacing, line.line, oddSpace, space, sideMargin, right)
 		texts = append(texts, formatted)
 	}
 	return texts, nil
@@ -397,6 +405,13 @@ func applyConvertedColor(str string, c color.Color) string {
 	return sb.String()
 }
 
+func borderColor(override, fallback string) string {
+	if override != "" {
+		return override
+	}
+	return fallback
+}
+
 func (b *Box) applyColorBar(topBar, bottomBar, title string, titleOffset int) (string, string, error) {
 	if b.titlePos != Top && b.titlePos != Bottom {
 		return topBar, bottomBar, nil
@@ -404,32 +419,40 @@ func (b *Box) applyColorBar(topBar, bottomBar, title string, titleOffset int) (s
 	if b.titleColor == "" || title == "" {
 		return topBar, bottomBar, nil
 	}
-	if b.color == "" {
-		return topBar, bottomBar, nil
-	}
-
-	converted, err := getConvertedColor(b.color)
-	if err != nil {
-		return "", "", err
-	}
-
-	colorBarTitle := func(bar string) string {
+	topColor := borderColor(b.topColor, b.color)
+	bottomColor := borderColor(b.bottomColor, b.color)
+	colorBarTitle := func(bar, color string) (string, error) {
+		if color == "" {
+			return bar, nil
+		}
+		converted, err := getConvertedColor(color)
+		if err != nil {
+			return "", err
+		}
 		strippedBar := ansi.Strip(bar)
 		strippedTitle := ansi.Strip(title)
 		end := titleOffset + len(strippedTitle)
 		if titleOffset < 0 || end > len(strippedBar) {
-			return bar
+			return bar, nil
 		}
 		b0 := applyConvertedColor(strippedBar[:titleOffset], converted)
 		b1 := applyConvertedColor(strippedBar[end:], converted)
-		return b0 + title + b1
+		return b0 + title + b1, nil
 	}
 
 	if b.titlePos == Top {
-		topBar = colorBarTitle(topBar)
+		var err error
+		topBar, err = colorBarTitle(topBar, topColor)
+		if err != nil {
+			return "", "", err
+		}
 	}
 	if b.titlePos == Bottom {
-		bottomBar = colorBarTitle(bottomBar)
+		var err error
+		bottomBar, err = colorBarTitle(bottomBar, bottomColor)
+		if err != nil {
+			return "", "", err
+		}
 	}
 
 	return topBar, bottomBar, nil


### PR DESCRIPTION
## Summary

- add TopBorderColor, RightBorderColor, BottomBorderColor, and LeftBorderColor fluent configuration methods
- preserve Color as the backward-compatible fallback while allowing individual side overrides
- color top and bottom corners with their corresponding horizontal border and preserve embedded TitleColor styling
- validate custom border colors during Render
- document the API and add a runnable custom_border_colors example

## Behavior

- side-specific colors override Color
- an empty side-specific color clears the override and restores the Color fallback
- top and bottom colors include their respective corner glyphs
- left and right colors apply to vertical border glyphs

## Tests

- GOCACHE=/tmp/box-cli-maker-go-cache go test -count=1 ./...
- GOCACHE=/tmp/box-cli-maker-go-cache go test -race -count=1 ./...
- GOCACHE=/tmp/box-cli-maker-go-cache go vet ./...
- git diff --check
- go run ./examples/custom_border_colors

Closes #57